### PR TITLE
Fix: Error when transferring without a parent folder

### DIFF
--- a/transatlanticTorrentExpress.py
+++ b/transatlanticTorrentExpress.py
@@ -12,7 +12,7 @@ except Exception:
   sys.exit(1)
 
 from logger import logger
-from utils import getConfig, readAvgSpeedFromDisk, writeAvgSpeedToDisk
+from utils import getConfig, readAvgSpeedFromDisk, writeAvgSpeedToDisk, VIDEO_EXTENSIONS
 
 ESTIMATED_TRANSFER_SPEED=readAvgSpeedFromDisk()
 TRANSFER_SPEED_UNIT="Mb/s"
@@ -118,8 +118,16 @@ def transferFiles(files, localPath, remotePath, host=None, user=None):
     file = os.path.join(remotePath, file)
     spaceEscapedFile = file.replace(' ', '\\ ')
 
+    # check if file is folder-less, if so create folder and update localPath
+    folderedLocalPath = None
+    filename, fileExtension = os.path.splitext(file)
+    if fileExtension in VIDEO_EXTENSIONS:
+      folderedLocalPath = os.path.join(localPath, filename)
+      os.makedirs(folderedLocalPath)
+
+    # Build rsync command
     if host and user:
-      cmd = "rsync -rz {}@{}:'{}' '{}'".format(user, host, spaceEscapedFile, localPath)
+      cmd = "rsync -rz {}@{}:'{}' '{}'".format(user, host, spaceEscapedFile, folderedLocalPath or localPath)
     else:
       cmd = "rsync -rz '{}' '{}'".format(spaceEscapedFile, localPath)
 

--- a/utils.py
+++ b/utils.py
@@ -38,7 +38,7 @@ def writeAvgSpeedToDisk(speed):
   path = os.path.join(pwd, '.avgspeed.txt')
 
   with open(path, 'w') as f:
-    f.write(str(int(speed)))
+    f.write(str(int(speed or 100)))
     f.close()
 
 def readAvgSpeedFromDisk():

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,14 @@ from configparser import RawConfigParser, NoOptionError
 
 pwd = os.path.dirname(os.path.abspath(__file__))
 
+VIDEO_EXTENSIONS = ('.3g2', '.3gp', '.3gp2', '.3gpp', '.60d', '.ajp', '.asf', '.asx', '.avchd', '.avi', '.bik',
+                    '.bix', '.box', '.cam', '.dat', '.divx', '.dmf', '.dv', '.dvr-ms', '.evo', '.flc', '.fli',
+                    '.flic', '.flv', '.flx', '.gvi', '.gvp', '.h264', '.m1v', '.m2p', '.m2v', '.m4e',
+                    '.m4v', '.mjp', '.mjpeg', '.mjpg', '.mkv', '.moov', '.mov', '.movhd', '.movie', '.movx', '.mp4',
+                    '.mpe', '.mpeg', '.mpg', '.mpv', '.mpv2', '.mxf', '.nsv', '.nut', '.ogg', '.ogm' '.ogv', '.omf',
+                    '.ps', '.qt', '.ram', '.rm', '.rmvb', '.swf', '.ts', '.vfw', '.vid', '.video', '.viv', '.vivo',
+                    '.vob', '.vro', '.wm', '.wmv', '.wmx', '.wrap', '.wvx', '.wx', '.x264', '.xvid')
+
 class NoneOptionConfigParser(RawConfigParser):
   def get(self, section, option):
     try:


### PR DESCRIPTION
This will check if file ends with a know video extension, if so use os.makedirs to create a folder at destination and update rsync destination with this folder.

Also ensure to always leave a default number of 100 in avg transfer speed file on disk.